### PR TITLE
Add SalesService with stock validation and RabbitMQ integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Ignore build output
+bin/
+obj/
+
+# Visual Studio files
+.vs/
+
+# Dotnet user settings
+*.user
+

--- a/SalesService/Controllers/OrdersController.cs
+++ b/SalesService/Controllers/OrdersController.cs
@@ -1,0 +1,58 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SalesService.Data;
+using SalesService.Models;
+using SalesService.Services;
+
+namespace SalesService.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class OrdersController : ControllerBase
+{
+    private readonly SalesDbContext _context;
+    private readonly IInventoryServiceClient _inventoryClient;
+    private readonly IRabbitMqPublisher _publisher;
+
+    public OrdersController(SalesDbContext context, IInventoryServiceClient inventoryClient, IRabbitMqPublisher publisher)
+    {
+        _context = context;
+        _inventoryClient = inventoryClient;
+        _publisher = publisher;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create(Order order, CancellationToken cancellationToken)
+    {
+        foreach (var item in order.Items)
+        {
+            var valid = await _inventoryClient.ValidateStockAsync(item.ProductId, item.Quantity, cancellationToken);
+            if (!valid)
+            {
+                return BadRequest($"Insufficient stock for product {item.ProductId}");
+            }
+        }
+
+        _context.Orders.Add(order);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        _publisher.PublishOrderConfirmed(order);
+
+        return CreatedAtAction(nameof(GetById), new { id = order.Id }, order);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<Order>> GetById(int id, CancellationToken cancellationToken)
+    {
+        var order = await _context.Orders
+            .Include(o => o.Items)
+            .FirstOrDefaultAsync(o => o.Id == id, cancellationToken);
+
+        if (order == null)
+        {
+            return NotFound();
+        }
+
+        return order;
+    }
+}

--- a/SalesService/Data/SalesDbContext.cs
+++ b/SalesService/Data/SalesDbContext.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using SalesService.Models;
+
+namespace SalesService.Data;
+
+public class SalesDbContext : DbContext
+{
+    public SalesDbContext(DbContextOptions<SalesDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Order> Orders => Set<Order>();
+    public DbSet<OrderItem> OrderItems => Set<OrderItem>();
+}

--- a/SalesService/Models/Order.cs
+++ b/SalesService/Models/Order.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+
+namespace SalesService.Models;
+
+public class Order
+{
+    public int Id { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public ICollection<OrderItem> Items { get; set; } = new List<OrderItem>();
+}

--- a/SalesService/Models/OrderItem.cs
+++ b/SalesService/Models/OrderItem.cs
@@ -1,0 +1,12 @@
+namespace SalesService.Models;
+
+public class OrderItem
+{
+    public int Id { get; set; }
+    public int ProductId { get; set; }
+    public int Quantity { get; set; }
+    public decimal UnitPrice { get; set; }
+
+    public int OrderId { get; set; }
+    public Order? Order { get; set; }
+}

--- a/SalesService/Program.cs
+++ b/SalesService/Program.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using SalesService.Data;
+using SalesService.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.AddDbContext<SalesDbContext>(options =>
+    options.UseInMemoryDatabase("SalesDb"));
+
+builder.Services.AddHttpClient<IInventoryServiceClient, InventoryServiceClient>(client =>
+{
+    var baseUrl = builder.Configuration["InventoryService:BaseUrl"] ?? "http://inventory-service";
+    client.BaseAddress = new Uri(baseUrl);
+});
+
+builder.Services.AddSingleton<IRabbitMqPublisher, RabbitMqPublisher>();
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.MapControllers();
+
+app.Run();

--- a/SalesService/SalesService.csproj
+++ b/SalesService/SalesService.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
+  </ItemGroup>
+</Project>

--- a/SalesService/Services/InventoryServiceClient.cs
+++ b/SalesService/Services/InventoryServiceClient.cs
@@ -1,0 +1,37 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SalesService.Services;
+
+public interface IInventoryServiceClient
+{
+    Task<bool> ValidateStockAsync(int productId, int quantity, CancellationToken cancellationToken);
+}
+
+public class InventoryServiceClient : IInventoryServiceClient
+{
+    private readonly HttpClient _httpClient;
+
+    public InventoryServiceClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<bool> ValidateStockAsync(int productId, int quantity, CancellationToken cancellationToken)
+    {
+        var response = await _httpClient.GetAsync($"/api/inventory/{productId}", cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            return false;
+        }
+
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        if (int.TryParse(content, out var available))
+        {
+            return available >= quantity;
+        }
+
+        return false;
+    }
+}

--- a/SalesService/Services/RabbitMqPublisher.cs
+++ b/SalesService/Services/RabbitMqPublisher.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Text;
+using System.Text.Json;
+using RabbitMQ.Client;
+using SalesService.Models;
+
+namespace SalesService.Services;
+
+public interface IRabbitMqPublisher : IDisposable
+{
+    void PublishOrderConfirmed(Order order);
+}
+
+public class RabbitMqPublisher : IRabbitMqPublisher
+{
+    private readonly IConnection _connection;
+    private readonly IModel _channel;
+
+    public RabbitMqPublisher(IConfiguration configuration)
+    {
+        var factory = new ConnectionFactory
+        {
+            HostName = configuration["RabbitMq:Host"] ?? "localhost"
+        };
+
+        _connection = factory.CreateConnection();
+        _channel = _connection.CreateModel();
+        _channel.QueueDeclare(queue: "order-confirmed", durable: false, exclusive: false, autoDelete: false, arguments: null);
+    }
+
+    public void PublishOrderConfirmed(Order order)
+    {
+        var message = JsonSerializer.Serialize(order);
+        var body = Encoding.UTF8.GetBytes(message);
+
+        _channel.BasicPublish(exchange: string.Empty, routingKey: "order-confirmed", basicProperties: null, body: body);
+    }
+
+    public void Dispose()
+    {
+        _channel.Dispose();
+        _connection.Dispose();
+    }
+}

--- a/SalesService/appsettings.json
+++ b/SalesService/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "InventoryService": {
+    "BaseUrl": "http://inventory-service"
+  },
+  "RabbitMq": {
+    "Host": "localhost"
+  }
+}


### PR DESCRIPTION
## Summary
- setup SalesService project with Entity Framework Core and RabbitMQ dependencies
- add order and order item models and EF Core context
- implement inventory validation via HTTP client
- publish RabbitMQ message when orders are saved

## Testing
- `dotnet build SalesService` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a60d815848833284be42d779afca2a