### PR TITLE
Add ApiGateway project with Ocelot and JWT auth

### DIFF
--- a/ApiGateway/ApiGateway.csproj
+++ b/ApiGateway/ApiGateway.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Ocelot" Version="18.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="ocelot.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/ApiGateway/Program.cs
+++ b/ApiGateway/Program.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using Ocelot.DependencyInjection;
+using Ocelot.Middleware;
+using System.Text;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Configuration.AddJsonFile("ocelot.json", optional: false, reloadOnChange: true);
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = builder.Configuration["Jwt:Issuer"],
+            ValidAudience = builder.Configuration["Jwt:Audience"],
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!))
+        };
+    });
+
+builder.Services.AddOcelot();
+
+var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+await app.UseOcelot();
+
+app.Run();

--- a/ApiGateway/README.md
+++ b/ApiGateway/README.md
@@ -1,0 +1,19 @@
+# ApiGateway
+
+Gateway construído com [Ocelot](https://github.com/ThreeMammals/Ocelot) para rotear chamadas aos serviços `InventoryService` e `SalesService` com autenticação JWT.
+
+## Rotas
+
+| Caminho (Upstream) | Métodos | Destino (Downstream) |
+|--------------------|---------|----------------------|
+| `/inventory/{*}`   | GET, POST, PUT, DELETE | `http://localhost:5001/api/inventory/{*}` |
+| `/sales/{*}`       | GET, POST, PUT, DELETE | `http://localhost:5002/api/sales/{*}` |
+
+### Parâmetros
+
+- `*` representa qualquer segmento adicional encaminhado ao serviço de destino.
+- Parâmetros de query string são encaminhados automaticamente.
+
+## Autenticação
+
+Todas as requisições precisam incluir um token JWT válido no cabeçalho `Authorization` utilizando o esquema Bearer.

--- a/ApiGateway/appsettings.json
+++ b/ApiGateway/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Jwt": {
+    "Key": "SuperSecretKey",
+    "Issuer": "MicroservicesIssuer",
+    "Audience": "MicroservicesAudience"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/ApiGateway/ocelot.json
+++ b/ApiGateway/ocelot.json
@@ -1,0 +1,33 @@
+{
+  "Routes": [
+    {
+      "DownstreamPathTemplate": "/api/inventory/{everything}",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        { "Host": "localhost", "Port": 5001 }
+      ],
+      "UpstreamPathTemplate": "/inventory/{everything}",
+      "UpstreamHttpMethod": ["GET", "POST", "PUT", "DELETE"],
+      "AuthenticationOptions": {
+        "AuthenticationProviderKey": "Bearer",
+        "AllowedScopes": []
+      }
+    },
+    {
+      "DownstreamPathTemplate": "/api/sales/{everything}",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        { "Host": "localhost", "Port": 5002 }
+      ],
+      "UpstreamPathTemplate": "/sales/{everything}",
+      "UpstreamHttpMethod": ["GET", "POST", "PUT", "DELETE"],
+      "AuthenticationOptions": {
+        "AuthenticationProviderKey": "Bearer",
+        "AllowedScopes": []
+      }
+    }
+  ],
+  "GlobalConfiguration": {
+    "BaseUrl": "http://localhost:8000"
+  }
+}


### PR DESCRIPTION
## Summary
- add ApiGateway project using Ocelot
- route InventoryService and SalesService through gateway
- enable JWT authentication and document routes

## Testing
- `dotnet build ApiGateway` *(fails: command not found)*
- `dotnet test ApiGateway` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a60d839430833280a48c2050d49b82