### PR TITLE
Add unit tests for Inventory and Sales services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: ["work"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/inventory-service/inventoryService.js
+++ b/inventory-service/inventoryService.js
@@ -1,0 +1,20 @@
+class InventoryService {
+  constructor() {
+    this.products = new Map();
+  }
+
+  createProduct(product) {
+    if (this.products.has(product.id)) {
+      throw new Error('Product already exists');
+    }
+    this.products.set(product.id, { ...product });
+  }
+
+  validateStock(productId, quantity) {
+    const product = this.products.get(productId);
+    if (!product) return false;
+    return product.stock >= quantity;
+  }
+}
+
+module.exports = InventoryService;

--- a/inventory-service/inventoryService.test.js
+++ b/inventory-service/inventoryService.test.js
@@ -1,0 +1,16 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const InventoryService = require('./inventoryService');
+
+test('InventoryService creates products and validates stock', () => {
+  const service = new InventoryService();
+  service.createProduct({ id: 'p1', name: 'Product 1', stock: 10 });
+  assert.strictEqual(service.validateStock('p1', 5), true);
+  assert.strictEqual(service.validateStock('p1', 15), false);
+});
+
+test('InventoryService throws when creating duplicate products', () => {
+  const service = new InventoryService();
+  service.createProduct({ id: 'p1', name: 'Product 1', stock: 10 });
+  assert.throws(() => service.createProduct({ id: 'p1', name: 'Product 1', stock: 5 }), /Product already exists/);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "microservicos-avanade",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "microservicos-avanade",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "microservicos-avanade",
+  "version": "1.0.0",
+  "description": "Microservices for Inventory and Sales with tests",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/sales-service/salesService.js
+++ b/sales-service/salesService.js
@@ -1,0 +1,16 @@
+class SalesService {
+  constructor(inventoryService, mqChannel) {
+    this.inventoryService = inventoryService;
+    this.mqChannel = mqChannel;
+  }
+
+  async createOrder(order) {
+    if (!this.inventoryService.validateStock(order.productId, order.quantity)) {
+      throw new Error('Insufficient stock');
+    }
+    await this.mqChannel.sendToQueue('orders', Buffer.from(JSON.stringify(order)));
+    return { status: 'created' };
+  }
+}
+
+module.exports = SalesService;

--- a/sales-service/salesService.test.js
+++ b/sales-service/salesService.test.js
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const SalesService = require('./salesService');
+
+test('SalesService creates order when stock is sufficient', async () => {
+  const inventoryMock = { validateStock: () => true };
+  let sent;
+  const channelMock = {
+    sendToQueue: (queue, msg) => {
+      sent = { queue, msg };
+    }
+  };
+  const service = new SalesService(inventoryMock, channelMock);
+  const order = { productId: 'p1', quantity: 2 };
+  await service.createOrder(order);
+  assert.deepStrictEqual(sent, { queue: 'orders', msg: Buffer.from(JSON.stringify(order)) });
+});
+
+test('SalesService throws error when stock is insufficient', async () => {
+  const inventoryMock = { validateStock: () => false };
+  let sendCalled = false;
+  const channelMock = {
+    sendToQueue: () => {
+      sendCalled = true;
+    }
+  };
+  const service = new SalesService(inventoryMock, channelMock);
+  const order = { productId: 'p1', quantity: 2 };
+  await assert.rejects(() => service.createOrder(order), /Insufficient stock/);
+  assert.strictEqual(sendCalled, false);
+});


### PR DESCRIPTION
## Summary
- implement InventoryService and SalesService modules with basic product and order logic
- add unit tests for product creation, stock validation, and order creation with mocked RabbitMQ and service calls
- configure GitHub Actions workflow to run tests in CI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a60d888f8c833299d86c113b9aa853