### PR TITLE
Configure RabbitMQ queue and resilience

### DIFF
--- a/SalesService/Services/RabbitMqPublisher.cs
+++ b/SalesService/Services/RabbitMqPublisher.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
+using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
 using SalesService.Models;
 
@@ -15,17 +17,25 @@ public class RabbitMqPublisher : IRabbitMqPublisher
 {
     private readonly IConnection _connection;
     private readonly IModel _channel;
+    private readonly ILogger<RabbitMqPublisher> _logger;
+    private readonly string _queueName;
 
-    public RabbitMqPublisher(IConfiguration configuration)
+    public RabbitMqPublisher(IConfiguration configuration, ILogger<RabbitMqPublisher> logger)
     {
+        _logger = logger;
+        _queueName = configuration["RabbitMq:QueueName"] ?? "order-confirmed";
         var factory = new ConnectionFactory
         {
-            HostName = configuration["RabbitMq:Host"] ?? "localhost"
+            HostName = configuration["RabbitMq:Host"] ?? "localhost",
+            AutomaticRecoveryEnabled = true
         };
 
+        _logger.LogInformation("Connecting to RabbitMQ at {Host}", factory.HostName);
         _connection = factory.CreateConnection();
+        _logger.LogInformation("RabbitMQ connection established");
         _channel = _connection.CreateModel();
-        _channel.QueueDeclare(queue: "order-confirmed", durable: false, exclusive: false, autoDelete: false, arguments: null);
+        _channel.QueueDeclare(queue: _queueName, durable: false, exclusive: false, autoDelete: false, arguments: null);
+        _logger.LogInformation("Declared queue {QueueName}", _queueName);
     }
 
     public void PublishOrderConfirmed(Order order)
@@ -33,12 +43,33 @@ public class RabbitMqPublisher : IRabbitMqPublisher
         var message = JsonSerializer.Serialize(order);
         var body = Encoding.UTF8.GetBytes(message);
 
-        _channel.BasicPublish(exchange: string.Empty, routingKey: "order-confirmed", basicProperties: null, body: body);
+        const int maxRetries = 3;
+        for (int attempt = 1; attempt <= maxRetries; attempt++)
+        {
+            try
+            {
+                _logger.LogInformation("Publishing message to {Queue} (attempt {Attempt})", _queueName, attempt);
+                _channel.BasicPublish(exchange: string.Empty, routingKey: _queueName, basicProperties: null, body: body);
+                _logger.LogInformation("Message published to {Queue}", _queueName);
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to publish message to {Queue} on attempt {Attempt}", _queueName, attempt);
+                if (attempt == maxRetries)
+                {
+                    throw;
+                }
+                Thread.Sleep(1000);
+            }
+        }
     }
 
     public void Dispose()
     {
+        _logger.LogInformation("Disposing RabbitMQ connection");
         _channel.Dispose();
         _connection.Dispose();
+        _logger.LogInformation("RabbitMQ connection disposed");
     }
 }

--- a/SalesService/appsettings.json
+++ b/SalesService/appsettings.json
@@ -3,6 +3,7 @@
     "BaseUrl": "http://inventory-service"
   },
   "RabbitMq": {
-    "Host": "localhost"
+    "Host": "localhost",
+    "QueueName": "sales_notifications"
   }
 }


### PR DESCRIPTION
## Summary
- add `sales_notifications` queue name to SalesService configuration
- read configured queue name in `RabbitMqPublisher` and enable automatic recovery with retry and logging

## Testing
- ❌ `dotnet build SalesService/SalesService.csproj` (dotnet: command not found)
- ⚠️ `apt-get update` (403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_68a61a86884c83329be0ca5bb880cfbd