### PR TITLE
Use SQL Server with environment-based connection string

### DIFF
--- a/InventoryService/InventoryService.csproj
+++ b/InventoryService/InventoryService.csproj
@@ -4,14 +4,16 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
     <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 </Project>
+

--- a/InventoryService/Migrations/20240920100000_InitialCreate.cs
+++ b/InventoryService/Migrations/20240920100000_InitialCreate.cs
@@ -12,12 +12,12 @@ namespace InventoryService.Migrations
                 name: "Products",
                 columns: table => new
                 {
-                    Id = table.Column<int>(type: "INTEGER", nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
-                    Name = table.Column<string>(type: "TEXT", nullable: false),
-                    Description = table.Column<string>(type: "TEXT", nullable: true),
-                    Price = table.Column<decimal>(type: "TEXT", nullable: false),
-                    Quantity = table.Column<int>(type: "INTEGER", nullable: false)
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Price = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    Quantity = table.Column<int>(type: "int", nullable: false)
                 },
                 constraints: table =>
                 {

--- a/InventoryService/Migrations/InventoryDbContextModelSnapshot.cs
+++ b/InventoryService/Migrations/InventoryDbContextModelSnapshot.cs
@@ -19,20 +19,20 @@ namespace InventoryService.Migrations
             {
                 b.Property<int>("Id")
                     .ValueGeneratedOnAdd()
-                    .HasColumnType("INTEGER");
+                    .HasColumnType("int");
 
                 b.Property<string>("Description")
-                    .HasColumnType("TEXT");
+                    .HasColumnType("nvarchar(max)");
 
                 b.Property<string>("Name")
                     .IsRequired()
-                    .HasColumnType("TEXT");
+                    .HasColumnType("nvarchar(max)");
 
                 b.Property<decimal>("Price")
-                    .HasColumnType("TEXT");
+                    .HasColumnType("decimal(18,2)");
 
                 b.Property<int>("Quantity")
-                    .HasColumnType("INTEGER");
+                    .HasColumnType("int");
 
                 b.HasKey("Id");
 

--- a/InventoryService/Program.cs
+++ b/InventoryService/Program.cs
@@ -4,12 +4,17 @@ using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.Configuration.AddEnvironmentVariables();
+
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+var connectionString = builder.Configuration["DATABASE_URL"]
+    ?? builder.Configuration.GetConnectionString("DefaultConnection");
+
 builder.Services.AddDbContext<InventoryDbContext>(options =>
-    options.UseSqlite(builder.Configuration.GetConnectionString("DefaultConnection")));
+    options.UseSqlServer(connectionString));
 
 builder.Services.AddHostedService<RabbitMqStockConsumer>();
 

--- a/InventoryService/appsettings.json
+++ b/InventoryService/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=inventory.db"
+    "DefaultConnection": ""
   },
   "RabbitMq": {
     "Host": "localhost",


### PR DESCRIPTION
## Summary
- Load connection strings from environment variables and switch EF Core to SQL Server
- Provide a new initial migration targeting SQL Server
- Replace hardcoded SQLite settings with placeholders

## Testing
- `npm test`
- `dotnet restore InventoryService/InventoryService.csproj` *(fails: command not found)*
- `dotnet ef migrations add InitialCreate --project InventoryService` *(fails: command not found)*
- `dotnet ef migrations script --project InventoryService` *(fails: command not found)*
- `dotnet ef database update --project InventoryService` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a61cc32e008332b74879549fbc900c