### PR TITLE
Use environment variables for service database config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/InventoryService/Program.cs
+++ b/InventoryService/Program.cs
@@ -4,12 +4,17 @@ using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.Configuration.AddEnvironmentVariables();
+
+var connectionString = Environment.GetEnvironmentVariable("DATABASE_URL")
+    ?? throw new InvalidOperationException("DATABASE_URL is not set.");
+
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 builder.Services.AddDbContext<InventoryDbContext>(options =>
-    options.UseSqlite(builder.Configuration.GetConnectionString("DefaultConnection")));
+    options.UseSqlite(connectionString));
 
 builder.Services.AddHostedService<RabbitMqStockConsumer>();
 

--- a/InventoryService/appsettings.json
+++ b/InventoryService/appsettings.json
@@ -1,7 +1,4 @@
 {
-  "ConnectionStrings": {
-    "DefaultConnection": "Data Source=inventory.db"
-  },
   "RabbitMq": {
     "Host": "localhost",
     "QueueName": "sales"

--- a/SalesService/Program.cs
+++ b/SalesService/Program.cs
@@ -4,9 +4,14 @@ using SalesService.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.Configuration.AddEnvironmentVariables();
+
+var connectionString = Environment.GetEnvironmentVariable("DATABASE_URL")
+    ?? throw new InvalidOperationException("DATABASE_URL is not set.");
+
 // Add services to the container.
 builder.Services.AddDbContext<SalesDbContext>(options =>
-    options.UseInMemoryDatabase("SalesDb"));
+    options.UseSqlite(connectionString));
 
 builder.Services.AddHttpClient<IInventoryServiceClient, InventoryServiceClient>(client =>
 {

--- a/SalesService/SalesService.csproj
+++ b/SalesService/SalesService.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
     <PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- load environment variables in InventoryService and SalesService
- fetch database connection from DATABASE_URL instead of hard-coded values
- configure CI to supply DATABASE_URL secret

## Testing
- `npm test`
- `dotnet build InventoryService` *(fails: command not found; attempted apt-get but repositories 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a61cda2ff48332a307dd738e29dfcf