### PR TITLE
Expose product quantity endpoint and return structured validation errors

### DIFF
--- a/ApiGateway/ocelot.json
+++ b/ApiGateway/ocelot.json
@@ -1,12 +1,12 @@
 {
   "Routes": [
     {
-      "DownstreamPathTemplate": "/api/inventory/{everything}",
+      "DownstreamPathTemplate": "/products/{everything}",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         { "Host": "localhost", "Port": 5001 }
       ],
-      "UpstreamPathTemplate": "/inventory/{everything}",
+      "UpstreamPathTemplate": "/products/{everything}",
       "UpstreamHttpMethod": ["GET", "POST", "PUT", "DELETE"],
       "AuthenticationOptions": {
         "AuthenticationProviderKey": "Bearer",

--- a/InventoryService/Controllers/ProductsController.cs
+++ b/InventoryService/Controllers/ProductsController.cs
@@ -32,13 +32,25 @@ namespace InventoryService.Controllers
             return await _context.Products.ToListAsync();
         }
 
+        [HttpGet("{id}")]
+        public async Task<ActionResult<object>> GetById(int id)
+        {
+            var product = await _context.Products.FindAsync(id);
+            if (product == null)
+            {
+                return NotFound(new { message = "Product not found" });
+            }
+
+            return Ok(new { quantity = product.Quantity });
+        }
+
         [HttpPut("{id}/stock")]
         public async Task<IActionResult> UpdateStock(int id, StockUpdateDto update)
         {
             var product = await _context.Products.FindAsync(id);
             if (product == null)
             {
-                return NotFound();
+                return NotFound(new { message = "Product not found" });
             }
             product.Quantity = update.Quantity;
             await _context.SaveChangesAsync();

--- a/SalesService/Controllers/OrdersController.cs
+++ b/SalesService/Controllers/OrdersController.cs
@@ -31,7 +31,7 @@ public class OrdersController : ControllerBase
             var valid = await _inventoryClient.ValidateStockAsync(item.ProductId, item.Quantity, cancellationToken);
             if (!valid)
             {
-                return BadRequest($"Insufficient stock for product {item.ProductId}");
+                return BadRequest(new { message = $"Insufficient stock for product {item.ProductId}" });
             }
         }
 


### PR DESCRIPTION
## Summary
- add `GET /products/{id}` in InventoryService returning available quantity
- consume `/products` in InventoryServiceClient and parse JSON
- return JSON error when stock is insufficient
- update gateway mapping to `/products`

## Testing
- `npm test`
- `dotnet build InventoryService/InventoryService.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a62afda2708332bca77d0ca1a127c0