### PR TITLE
feat: send stock adjustment messages

### DIFF
--- a/SalesService/Messages/StockAdjustmentMessage.cs
+++ b/SalesService/Messages/StockAdjustmentMessage.cs
@@ -1,0 +1,7 @@
+namespace SalesService.Messages;
+
+public class StockAdjustmentMessage
+{
+    public int ProductId { get; set; }
+    public int QuantitySold { get; set; }
+}


### PR DESCRIPTION
## Summary
- send per-item stock adjustments on order confirmation
- consume stock adjustments and log processing details

## Testing
- `dotnet build SalesService/SalesService.csproj` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a62c17153883328aaa73a55a1a478b