### PR TITLE
Propagate bearer token to inventory service

### DIFF
--- a/SalesService/Program.cs
+++ b/SalesService/Program.cs
@@ -24,6 +24,8 @@ builder.Services.AddHttpClient<IInventoryServiceClient, InventoryServiceClient>(
     client.BaseAddress = new Uri(baseUrl);
 });
 
+builder.Services.AddHttpContextAccessor();
+
 builder.Services.AddSingleton<IRabbitMqPublisher, RabbitMqPublisher>();
 builder.Services.AddControllers();
 

--- a/SalesService/Services/InventoryServiceClient.cs
+++ b/SalesService/Services/InventoryServiceClient.cs
@@ -1,7 +1,9 @@
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 
 namespace SalesService.Services;
 
@@ -13,14 +15,23 @@ public interface IInventoryServiceClient
 public class InventoryServiceClient : IInventoryServiceClient
 {
     private readonly HttpClient _httpClient;
+    private readonly IHttpContextAccessor _httpContextAccessor;
 
-    public InventoryServiceClient(HttpClient httpClient)
+    public InventoryServiceClient(HttpClient httpClient, IHttpContextAccessor httpContextAccessor)
     {
         _httpClient = httpClient;
+        _httpContextAccessor = httpContextAccessor;
     }
 
     public async Task<bool> ValidateStockAsync(int productId, int quantity, CancellationToken cancellationToken)
     {
+        var token = _httpContextAccessor.HttpContext?.Request.Headers["Authorization"].ToString();
+        if (!string.IsNullOrWhiteSpace(token))
+        {
+            token = token.StartsWith("Bearer ") ? token.Substring("Bearer ".Length) : token;
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+
         var response = await _httpClient.GetAsync($"/products/{productId}", cancellationToken);
         if (!response.IsSuccessStatusCode)
         {


### PR DESCRIPTION
## Summary
- inject IHttpContextAccessor into inventory client
- forward Authorization header to InventoryService
- register HttpContextAccessor in program startup

## Testing
- ⚠️ `dotnet build SalesService/SalesService.csproj` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a630c8344883328a949c166300c6cd