### PR TITLE
Align RabbitMQ queue configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ graph TD
 - **AuthService**: emite tokens **JWT** via `/login`.
 - **InventoryService**: catálogo e controle de estoque, protegido por JWT.
 - **SalesService**: criação/consulta de pedidos, valida estoque e publica eventos de venda.
-- **RabbitMQ**: mensageria para notificações e integração assíncrona.
+- **RabbitMQ**: mensageria para notificações e integração assíncrona. A fila padrão utilizada pelos serviços é `sales`.
 - **Bancos Relacionais**: um por serviço (ex.: SQL Server/PostgreSQL).
 
 ## Requisitos de Ambiente

--- a/SalesService/Services/RabbitMqPublisher.cs
+++ b/SalesService/Services/RabbitMqPublisher.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
 using SalesService.Messages;
@@ -24,10 +25,10 @@ public class RabbitMqPublisher : IRabbitMqPublisher
     public RabbitMqPublisher(IConfiguration configuration, ILogger<RabbitMqPublisher> logger)
     {
         _logger = logger;
-        _queueName = configuration["RabbitMq:QueueName"] ?? "order-confirmed";
+        _queueName = configuration.GetValue<string>("RabbitMq:QueueName") ?? "sales";
         var factory = new ConnectionFactory
         {
-            HostName = configuration["RabbitMq:Host"] ?? "localhost",
+            HostName = configuration.GetValue<string>("RabbitMq:Host") ?? "localhost",
             AutomaticRecoveryEnabled = true
         };
 

--- a/SalesService/appsettings.json
+++ b/SalesService/appsettings.json
@@ -7,7 +7,7 @@
   },
   "RabbitMq": {
     "Host": "localhost",
-    "QueueName": "sales_notifications"
+    "QueueName": "sales"
   },
   "Jwt": {
     "Key": "SuperSecretKey",


### PR DESCRIPTION
## Summary
- Use a shared RabbitMQ queue name `sales` across services
- Load queue/host settings from the same configuration key in `RabbitMqPublisher`
- Document default queue name in the project README

## Testing
- `npm test`
- `dotnet test InventoryService/InventoryService.csproj` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a634166fc08332a9d1c8f0b1bcf14b