### PR TITLE
Add order status and listing endpoint

### DIFF
--- a/SalesService/Controllers/OrdersController.cs
+++ b/SalesService/Controllers/OrdersController.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using SalesService.Data;
 using SalesService.Models;
 using SalesService.Services;
+using System.Collections.Generic;
 
 namespace SalesService.Controllers;
 
@@ -21,6 +22,16 @@ public class OrdersController : ControllerBase
         _context = context;
         _inventoryClient = inventoryClient;
         _publisher = publisher;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<Order>>> GetAll(CancellationToken cancellationToken)
+    {
+        var orders = await _context.Orders
+            .Include(o => o.Items)
+            .ToListAsync(cancellationToken);
+
+        return orders;
     }
 
     [HttpPost]

--- a/SalesService/Migrations/20250820190944_AddStatusToOrders.cs
+++ b/SalesService/Migrations/20250820190944_AddStatusToOrders.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SalesService.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStatusToOrders : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Status",
+                table: "Orders",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "Pending");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "Orders");
+        }
+    }
+}

--- a/SalesService/Migrations/SalesDbContextModelSnapshot.cs
+++ b/SalesService/Migrations/SalesDbContextModelSnapshot.cs
@@ -25,6 +25,10 @@ namespace SalesService.Migrations
                 b.Property<DateTime>("CreatedAt")
                     .HasColumnType("datetime2");
 
+                b.Property<string>("Status")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(max)");
+
                 b.HasKey("Id");
 
                 b.ToTable("Orders");

--- a/SalesService/Models/Order.cs
+++ b/SalesService/Models/Order.cs
@@ -7,5 +7,6 @@ public class Order
 {
     public int Id { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public string Status { get; set; } = "Pending";
     public ICollection<OrderItem> Items { get; set; } = new List<OrderItem>();
 }

--- a/SalesService/README.md
+++ b/SalesService/README.md
@@ -1,5 +1,15 @@
 # SalesService
 
+## Endpoints
+
+- `GET /api/orders`: lists all orders with their current status.
+- `GET /api/orders/{id}`: retrieves a specific order.
+- `POST /api/orders`: creates a new order.
+
+## Order Status
+
+Each order includes a `Status` field (default: `Pending`) to track its processing state.
+
 ## Generating EF Core Migration Scripts
 
 Set the `DATABASE_URL` environment variable to the connection string for the sales database. Examples:


### PR DESCRIPTION
## Summary
- add `Status` field to orders
- provide `GET /api/orders` endpoint for listing orders with status
- include EF migration and docs updates

## Testing
- `dotnet build SalesService` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a63565caf483328edc5b9c7de77289