### PR TITLE
Add xUnit tests for microservices and update pipeline

### DIFF
--- a/AuthService.Tests/AuthService.Tests.csproj
+++ b/AuthService.Tests/AuthService.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AuthService\AuthService.csproj" />
+  </ItemGroup>
+</Project>

--- a/AuthService.Tests/AuthServiceTests.cs
+++ b/AuthService.Tests/AuthServiceTests.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace AuthService.Tests;
+
+public class AuthServiceTests
+{
+    [Fact]
+    public async Task Login_ReturnsToken()
+    {
+        var factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment("Development");
+                builder.ConfigureAppConfiguration((context, config) =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["Jwt:Key"] = "secretsecretsecretsecret",
+                        ["Jwt:Issuer"] = "test",
+                        ["Jwt:Audience"] = "test"
+                    });
+                });
+            });
+
+        var client = factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/login", new { Username = "alice" });
+        response.EnsureSuccessStatusCode();
+        using var stream = await response.Content.ReadAsStreamAsync();
+        using var json = await JsonDocument.ParseAsync(stream);
+        Assert.True(json.RootElement.TryGetProperty("token", out _));
+    }
+}

--- a/AuthService/Program.cs
+++ b/AuthService/Program.cs
@@ -48,3 +48,5 @@ app.MapPost("/login", (UserLogin login) =>
 app.Run("http://localhost:5003");
 
 record UserLogin(string Username);
+
+public partial class Program { }

--- a/InventoryService.Tests/InventoryService.Tests.csproj
+++ b/InventoryService.Tests/InventoryService.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\InventoryService\InventoryService.csproj" />
+  </ItemGroup>
+</Project>

--- a/InventoryService.Tests/ProductsControllerTests.cs
+++ b/InventoryService.Tests/ProductsControllerTests.cs
@@ -1,0 +1,33 @@
+using System;
+using InventoryService.Controllers;
+using InventoryService.Data;
+using InventoryService.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace InventoryService.Tests;
+
+public class ProductsControllerTests
+{
+    private static InventoryDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<InventoryDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new InventoryDbContext(options);
+    }
+
+    [Fact]
+    public async Task Create_Product_PersistsAndReturnsCreated()
+    {
+        await using var db = CreateDbContext();
+        var controller = new ProductsController(db);
+        var product = new Product { Name = "Item", Price = 10m, Quantity = 5 };
+        var result = await controller.Create(product);
+        var created = Assert.IsType<CreatedAtActionResult>(result.Result);
+        var returned = Assert.IsType<Product>(created.Value);
+        Assert.Equal("Item", returned.Name);
+        Assert.Equal(1, await db.Products.CountAsync());
+    }
+}

--- a/InventoryService/Program.cs
+++ b/InventoryService/Program.cs
@@ -59,3 +59,5 @@ app.UseAuthorization();
 app.MapControllers();
 
 app.Run();
+
+public partial class Program { }

--- a/SalesService.Tests/InventoryServiceClientTests.cs
+++ b/SalesService.Tests/InventoryServiceClientTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using SalesService.Services;
+using Xunit;
+
+namespace SalesService.Tests;
+
+public class InventoryServiceClientTests
+{
+    private class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+        public StubHandler(HttpResponseMessage response) => _response = response;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) => Task.FromResult(_response);
+    }
+
+    [Fact]
+    public async Task ValidateStockAsync_ReturnsTrue_WhenQuantitySufficient()
+    {
+        var json = "{\"quantity\":5}";
+        var handler = new StubHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) });
+        var client = new HttpClient(handler) { BaseAddress = new Uri("http://test") };
+        var accessor = new HttpContextAccessor { HttpContext = new DefaultHttpContext() };
+        var service = new InventoryServiceClient(client, accessor);
+        var result = await service.ValidateStockAsync(1, 3, CancellationToken.None);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task ValidateStockAsync_ReturnsFalse_WhenQuantityInsufficient()
+    {
+        var json = "{\"quantity\":2}";
+        var handler = new StubHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) });
+        var client = new HttpClient(handler) { BaseAddress = new Uri("http://test") };
+        var accessor = new HttpContextAccessor { HttpContext = new DefaultHttpContext() };
+        var service = new InventoryServiceClient(client, accessor);
+        var result = await service.ValidateStockAsync(1, 3, CancellationToken.None);
+        Assert.False(result);
+    }
+}

--- a/SalesService.Tests/OrdersControllerTests.cs
+++ b/SalesService.Tests/OrdersControllerTests.cs
@@ -1,0 +1,54 @@
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SalesService.Controllers;
+using SalesService.Data;
+using SalesService.Models;
+using SalesService.Services;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SalesService.Tests;
+
+public class OrdersControllerTests
+{
+    private static SalesDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<SalesDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new SalesDbContext(options);
+    }
+
+    [Fact]
+    public async Task Create_ReturnsCreated_WhenStockValid()
+    {
+        await using var db = CreateDb();
+        var inventory = new StubInventory(true);
+        var publisher = new StubPublisher();
+        var controller = new OrdersController(db, inventory, publisher);
+        var order = new Order
+        {
+            Items = new List<OrderItem> { new OrderItem { ProductId = 1, Quantity = 1, UnitPrice = 10m } }
+        };
+        var result = await controller.Create(order, CancellationToken.None);
+        var created = Assert.IsType<CreatedAtActionResult>(result);
+        Assert.Equal(1, await db.Orders.CountAsync());
+        Assert.Single(publisher.Published);
+    }
+
+    private sealed class StubInventory : IInventoryServiceClient
+    {
+        private readonly bool _valid;
+        public StubInventory(bool valid) => _valid = valid;
+        public Task<bool> ValidateStockAsync(int productId, int quantity, CancellationToken cancellationToken) => Task.FromResult(_valid);
+    }
+
+    private sealed class StubPublisher : IRabbitMqPublisher
+    {
+        public List<Order> Published { get; } = new();
+        public void PublishOrderConfirmed(Order order) => Published.Add(order);
+    }
+}

--- a/SalesService.Tests/SalesService.Tests.csproj
+++ b/SalesService.Tests/SalesService.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SalesService\SalesService.csproj" />
+  </ItemGroup>
+</Project>

--- a/SalesService/Program.cs
+++ b/SalesService/Program.cs
@@ -53,3 +53,5 @@ app.UseAuthorization();
 
 app.MapControllers();
 app.Run();
+
+public partial class Program { }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "description": "Microservices for Inventory and Sales with tests",
   "scripts": {
-    "test": "node --test"
+    "test": "dotnet test"
   }
 }


### PR DESCRIPTION
## Summary
- add xUnit projects for AuthService, InventoryService and SalesService
- cover product creation, stock validation and order creation
- wire `dotnet test` into the default test script

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6387d36308332b182f036c2ee1266