### PR TITLE
Add default SQLite connection and env override docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ graph TD
 
 1. Instale e suba RabbitMQ e o banco.
 2. Configure strings de conexão/variáveis de ambiente dos serviços.
+   O `SalesService` usa SQLite local por padrão (`Data Source=sales.db`). Para utilizar outro banco, defina a variável de ambiente `DATABASE_URL`.
+
+   ```bash
+   export DATABASE_URL="Server=localhost;Database=SalesDb;User Id=sa;Password=Your_password123;"
+   ```
+
 3. Compile e execute:
    ```bash
    dotnet build

--- a/SalesService/appsettings.json
+++ b/SalesService/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": ""
+    "DefaultConnection": "Data Source=sales.db"
   },
   "InventoryService": {
     "BaseUrl": "http://inventory-service"


### PR DESCRIPTION
## Summary
- configure SalesService to use a local SQLite database by default
- document how to override the connection string via the `DATABASE_URL` environment variable

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68a63a406af48332aea0856f6b889a85