### PR TITLE
Configure SalesService to use port 5001

### DIFF
--- a/SalesService/Program.cs
+++ b/SalesService/Program.cs
@@ -6,6 +6,7 @@ using SalesService.Services;
 using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
+builder.WebHost.UseUrls("http://localhost:5001");
 
 // Carrega variáveis de ambiente
 builder.Configuration.AddEnvironmentVariables();


### PR DESCRIPTION
## Summary
- configure SalesService to listen on http://localhost:5001

## Testing
- `dotnet build SalesService/SalesService.csproj` *(fails: command not found: dotnet)*
- `dotnet run --project SalesService` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: The repository ... InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a642ecc2688332bba8f84d722543a8