### PR TITLE
Configure ApiGateway to use localhost:8000

### DIFF
--- a/ApiGateway/Program.cs
+++ b/ApiGateway/Program.cs
@@ -25,6 +25,8 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 
 builder.Services.AddOcelot();
 
+builder.WebHost.UseUrls("http://localhost:8000");
+
 var app = builder.Build();
 
 app.UseAuthentication();


### PR DESCRIPTION
## Summary
- set web host URL to http://localhost:8000 for ApiGateway

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a647c37a808332ab12c10bac3cdcd8