### PR TITLE
Configure InventoryService to run on port 5001

### DIFF
--- a/InventoryService/Program.cs
+++ b/InventoryService/Program.cs
@@ -39,6 +39,8 @@ builder.Services.AddDbContext<InventoryDbContext>(options =>
 
 builder.Services.AddHostedService<RabbitMqStockConsumer>();
 
+builder.WebHost.UseUrls("http://localhost:5001");
+
 var app = builder.Build();
 
 using (var scope = app.Services.CreateScope())


### PR DESCRIPTION
## Summary
- configure InventoryService web host to listen on http://localhost:5001

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a647c8700483328559a8307cc5df2e