### PR TITLE
Update AuthService port to 5004

### DIFF
--- a/ApiGateway/ocelot.json
+++ b/ApiGateway/ocelot.json
@@ -48,7 +48,7 @@
       "DownstreamHostAndPorts": [
         {
           "Host": "localhost",
-          "Port": 5003
+          "Port": 5004
         }
       ],
       "UpstreamPathTemplate": "/auth/login",

--- a/AuthService/Program.cs
+++ b/AuthService/Program.cs
@@ -45,7 +45,7 @@ app.MapPost("/login", (UserLogin login) =>
 })
 .WithName("Login");
 
-app.Run("http://localhost:5003");
+app.Run("http://localhost:5004");
 
 record UserLogin(string Username);
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Os endpoints podem ser acessados pelo API Gateway (`http://localhost:3000`).
 1. Obtenha um token:
 
 ```bash
-curl -X POST http://localhost:3001/login \
+curl -X POST http://localhost:5004/login \
   -H "Content-Type: application/json" \
   -d '{"username":"user","password":"pass"}'
 ```


### PR DESCRIPTION
## Summary
- run AuthService on port 5004 instead of 5003
- adjust ApiGateway login route to new AuthService port
- update documentation to use port 5004 for token request

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a64fcf9a3c83328f93098736b738a2